### PR TITLE
Feat/add cmakelists

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*]
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# build files
+build/
+
+# vs-code
+.vscode/
+
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,88 @@
+cmake_minimum_required(VERSION 3.28)
+
+project("imgui_md" LANGUAGES C CXX)
+
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# --- #
+
+if(NOT COMMAND CPMAddPackage)
+    include(cmake/get_cpm.cmake)
+endif()
+
+
+if(NOT TARGET ImGui)
+    # ----- Dear ImGui (docking branch) -----
+    message(STATUS "[imgui] ImGui not present, fetching via CPM")
+    CPMAddPackage(
+        NAME ImGui
+        VERSION 1.92.6-docking
+        GIT_SHALLOW TRUE
+        GITHUB_REPOSITORY ocornut/imgui
+        DOWNLOAD_ONLY ON
+    )
+
+    # ----- ImGui core static library -----
+
+    add_library(ImGui STATIC)
+    target_sources(ImGui
+        PRIVATE
+            ${ImGui_SOURCE_DIR}/imgui.cpp
+            ${ImGui_SOURCE_DIR}/imgui.h
+            ${ImGui_SOURCE_DIR}/imgui_demo.cpp
+            ${ImGui_SOURCE_DIR}/imgui_draw.cpp
+            ${ImGui_SOURCE_DIR}/imgui_internal.h
+            ${ImGui_SOURCE_DIR}/imgui_tables.cpp
+            ${ImGui_SOURCE_DIR}/imgui_widgets.cpp
+            ${ImGui_SOURCE_DIR}/imstb_rectpack.h
+            ${ImGui_SOURCE_DIR}/imstb_textedit.h
+            ${ImGui_SOURCE_DIR}/imstb_truetype.h
+    )
+    target_include_directories(ImGui
+        PUBLIC
+            ${ImGui_SOURCE_DIR}
+    )
+else()
+    message(STATUS "[imgui] ImGui already provided by consumer, skipping")
+endif()
+
+if(NOT TARGET md4c)
+    # ----- MD4C (CommonMark parser, C library) -----
+    #
+    # Pulled via CPM. MD4C is the parser imgui_md is built on.
+    # We disable md2html and md4c-html since this library only needs the parser core.
+    message(STATUS "[md4c] md4c not present, fetching via CPM")
+    CPMAddPackage(
+        NAME md4c
+        VERSION 0.5.3
+        GIT_SHALLOW TRUE
+        GITHUB_REPOSITORY mity/md4c
+        GIT_TAG release-0.5.3
+        OPTIONS
+            "BUILD_MD2HTML_EXECUTABLE OFF"
+            "BUILD_SHARED_LIBS OFF"
+    )
+
+
+else()
+    message(STATUS "[md4c] md4c already provided by consumer, skipping")
+endif()
+
+add_library(imgui_md STATIC)
+
+target_sources(imgui_md
+    PRIVATE
+        imgui_md.h
+        imgui_md.cpp
+)
+target_include_directories(imgui_md
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(imgui_md PUBLIC ImGui md4c)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
+# INTRO
+Fork of [mekhontsev/imgui_md](https://github.com/mekhontsev/imgui_md) with addition and fixes, read below for the details.
+
 # imgui_md
 Markdown renderer for [Dear ImGui](https://github.com/ocornut/imgui) using [MD4C](https://github.com/mity/md4c) parser.
 
-C++11 or above
+C++11 or above.
+ImGui 1.92.6 or above.
 
 imgui_md currently supports the following markdown functionality:
 
   * Wrapped text
-  * Headers 
+  * Headers
   * Emphasis
   * Ordered and unordered list, sub-lists
   * Link
   * Image
-  * Horizontal rule	
+  * Horizontal rule
   * Table
   * Underline
   * Strikethrough
@@ -38,7 +42,7 @@ extern ImFont* g_font_bold;
 extern ImFont* g_font_bold_large;
 extern ImTextureID g_texture1;
 
-struct my_markdown : public imgui_md 
+struct my_markdown : public imgui_md
 {
 	ImFont* get_font() const override
 	{
@@ -74,7 +78,7 @@ struct my_markdown : public imgui_md
 		nfo.col_border = { 0,0,0,0 };
 		return true;
 	}
-	
+
 	void html_div(const std::string& dclass, bool e) override
 	{
 		if (dclass == "red") {
@@ -154,5 +158,6 @@ Border | **is not** | visible
 
 [Martin Mitáš for MD4C](https://github.com/mity/md4c)
 
-[Omar Cornut for Dear ImGui](https://github.com/ocornut/imgui)  
+[Omar Cornut for Dear ImGui](https://github.com/ocornut/imgui)
 
+[Dmitry Mekhontsev for original version of imgui_md](https://github.com/mekhontsev/imgui_md)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Fork of [mekhontsev/imgui_md](https://github.com/mekhontsev/imgui_md) with addit
 # imgui_md
 Markdown renderer for [Dear ImGui](https://github.com/ocornut/imgui) using [MD4C](https://github.com/mity/md4c) parser.
 
-C++11 or above.
+C++11 or above.<br/>
 ImGui 1.92.6 or above.
 
 imgui_md currently supports the following markdown functionality:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ Fork of [mekhontsev/imgui_md](https://github.com/mekhontsev/imgui_md) with addit
 
 My changes to Dmitry Mekhontsev library:
 - ImGui dynamic font support;
-- short delay before to show a links tooltip.
+- short delay before to show a links tool-tip;
+- render tables using ImGui specific API instead of draw them in raw way;
+- table columns width no more limited to the header text width;
+- the text inside the table cells wrap if it's to long.
 
 # imgui_md
 Markdown renderer for [Dear ImGui](https://github.com/ocornut/imgui) using [MD4C](https://github.com/mity/md4c) parser.
@@ -29,7 +32,7 @@ imgui_md currently supports the following markdown functionality:
 Most format tags can be mixed!
 
 Current tables limitations:
-  * Width of the columns are defined by header
+  * ~~Width of the columns are defined by header~~
   * Cells are always left aligned
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # INTRO
-Fork of [mekhontsev/imgui_md](https://github.com/mekhontsev/imgui_md) with addition and fixes, read below for the details.
+Fork of [mekhontsev/imgui_md](https://github.com/mekhontsev/imgui_md) with addition and fixes.
+
+My changes to Dmitry Mekhontsev library:
+- ImGui dynamic font support;
+- short delay before to show a links tooltip.
 
 # imgui_md
 Markdown renderer for [Dear ImGui](https://github.com/ocornut/imgui) using [MD4C](https://github.com/mity/md4c) parser.
 
-C++11 or above.<br/>
-ImGui 1.92.6 or above.
+C++ 11 or above.<br/>
+ImGui API v1.92 or above.
 
 imgui_md currently supports the following markdown functionality:
 

--- a/cmake/get_cpm.cmake
+++ b/cmake/get_cpm.cmake
@@ -1,0 +1,22 @@
+# Downloads CPM.cmake on first configure and caches it under the build directory.
+# Pattern documented at https://github.com/cpm-cmake/CPM.cmake#adding-cpm
+#
+# Why download on demand instead of vendoring CPM.cmake (~45 KB) in the repo?
+# Less noise in source tree, version is explicit, and the cache is build-dir local.
+
+set(CPM_DOWNLOAD_VERSION 0.40.8)
+
+# TODO: pin EXPECTED_HASH once the version is confirmed working — supply-chain hygiene.
+# Without it, a compromised GitHub release would go undetected. For PoC bootstrap only.
+
+set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+
+if(NOT EXISTS ${CPM_DOWNLOAD_LOCATION})
+    message(STATUS "Downloading CPM.cmake v${CPM_DOWNLOAD_VERSION} to ${CPM_DOWNLOAD_LOCATION}")
+    file(DOWNLOAD
+        "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake"
+        "${CPM_DOWNLOAD_LOCATION}"
+    )
+endif()
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/imgui_md.cpp
+++ b/imgui_md.cpp
@@ -293,8 +293,12 @@ void imgui_md::set_href(bool e, const MD_ATTRIBUTE& src)
 void imgui_md::set_font(bool e)
 {
 	if (e) {
-		ImFont *font = get_font();
-		ImGui::PushFont(font, font != nullptr ? font->LegacySize : 0.0f);
+		font_info info;
+		get_font(info);
+		if(info.font != nullptr)
+			ImGui::PushFont(info.font, info.size != 0.0f ? info.size : info.font->LegacySize);
+		else
+			ImGui::PushFont(nullptr, 0.0f);
 	} else {
 		ImGui::PopFont();
 	}
@@ -754,24 +758,30 @@ int imgui_md::print(const char* str, const char* str_end)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ImFont* imgui_md::get_font() const
+void imgui_md::get_font(font_info &info) const
 {
-	return nullptr;//default font
+	//default font
+	info.font = nullptr;
+	//default size of the font
+	info.size = 0.0f;
 
 	//Example:
 #if 0
+	info.size = 0.0f;
+
 	if (m_is_table_header) {
-		return g_font_bold;
+		info.font = g_font_bold;
+		return;
 	}
 
 	switch (m_hlevel)
 	{
 	case 0:
-		return m_is_strong ? g_font_bold : g_font_regular;
+		info.font = m_is_strong ? g_font_bold : g_font_regular;
 	case 1:
-		return g_font_bold_large;
+		info.font = g_font_bold_large;
 	default:
-		return g_font_bold;
+		info.font = g_font_bold;
 	}
 #endif
 

--- a/imgui_md.cpp
+++ b/imgui_md.cpp
@@ -293,7 +293,8 @@ void imgui_md::set_href(bool e, const MD_ATTRIBUTE& src)
 void imgui_md::set_font(bool e)
 {
 	if (e) {
-		ImGui::PushFont(get_font());
+		ImFont *font = get_font();
+		ImGui::PushFont(font, font != nullptr ? font->LegacySize : 0.0f);
 	} else {
 		ImGui::PopFont();
 	}
@@ -353,7 +354,7 @@ void imgui_md::SPAN_IMG(const MD_SPAN_IMG_DETAIL* d, bool e)
 		image_info nfo;
 		if (get_image(nfo)) {
 
-			const float scale = ImGui::GetIO().FontGlobalScale;
+			const float scale  = ImGui::GetStyle().FontScaleMain;
 			nfo.size.x *= scale;
 			nfo.size.y *= scale;
 
@@ -365,7 +366,7 @@ void imgui_md::SPAN_IMG(const MD_SPAN_IMG_DETAIL* d, bool e)
 				nfo.size.y = csz.x * r;
 			}
 
-			ImGui::Image(nfo.texture_id, nfo.size, nfo.uv0, nfo.uv1, nfo.col_tint, nfo.col_border);
+			ImGui::Image(nfo.texture_id, nfo.size, nfo.uv0, nfo.uv1);
 
 			if (ImGui::IsItemHovered()) {
 
@@ -414,7 +415,7 @@ void imgui_md::SPAN_DEL(bool e)
 
 void imgui_md::render_text(const char* str, const char* str_end)
 {
-	const float scale = ImGui::GetIO().FontGlobalScale;
+	const float scale   = ImGui::GetStyle().FontScaleMain;
 	const ImGuiStyle& s = ImGui::GetStyle();
 	bool is_lf = false;
 
@@ -432,7 +433,7 @@ void imgui_md::render_text(const char* str, const char* str_end)
 				wl -= ImGui::GetCursorPosX();
 			}
 
-			te = ImGui::GetFont()->CalcWordWrapPositionA(
+			te = ImGui::GetFont()->CalcWordWrapPosition(
 				scale, str, str_end, wl);
 
 			if (te == str)++te;
@@ -779,7 +780,7 @@ ImFont* imgui_md::get_font() const
 ImVec4 imgui_md::get_color() const
 {
 	if (!m_href.empty()) {
-		return ImGui::GetStyle().Colors[ImGuiCol_ButtonHovered];
+		return ImGui::GetStyle().Colors[ImGuiCol_TextLink];
 	}
 	return  ImGui::GetStyle().Colors[ImGuiCol_Text];
 }
@@ -790,12 +791,14 @@ bool imgui_md::get_image(image_info& nfo) const
 	//Use m_href to identify images
 	
 	//Example - Imgui font texture
+#ifdef IMGUI_HAS_TEXTURES
+	nfo.texture_id = ImGui::GetIO().Fonts->TexRef.GetTexID();
+#else
 	nfo.texture_id = ImGui::GetIO().Fonts->TexID;
+#endif
 	nfo.size = { 100,50 };
 	nfo.uv0 = { 0,0 };
 	nfo.uv1 = { 1,1 };
-	nfo.col_tint = { 1,1,1,1 };
-	nfo.col_border = { 0,0,0,0 };
 
 	return true;
 };

--- a/imgui_md.cpp
+++ b/imgui_md.cpp
@@ -204,7 +204,7 @@ void imgui_md::BLOCK_TABLE(const MD_BLOCK_TABLE_DETAIL*, bool e)
 			const float xmax = m_table_col_pos.back();
 			for (int i = 0; i < m_table_row_pos.size(); ++i) {
 				const float p = m_table_row_pos[i];
-				dl->AddLine(ImVec2(xmin, p), ImVec2(xmax, p), c, 
+				dl->AddLine(ImVec2(xmin, p), ImVec2(xmax, p), c,
 					i == 1 && m_table_header_highlight ? 2.0f : 1.0f);
 			}
 
@@ -270,14 +270,14 @@ void imgui_md::BLOCK_TD(const MD_BLOCK_TD_DETAIL*, bool e)
 		ImGui::SetCursorPosX(p.x);
 		if (p.y > m_table_last_pos.y)m_table_last_pos.y = p.y;
 	}
-	ImGui::TextUnformatted(""); 
-	
+	ImGui::TextUnformatted("");
+
 	if (!m_table_border && e && m_table_next_column==1 ) {
 		ImGui::SameLine(0.0f, 0.0f);
 	} else {
 		ImGui::SameLine();
 	}
-	
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -419,7 +419,6 @@ void imgui_md::SPAN_DEL(bool e)
 
 void imgui_md::render_text(const char* str, const char* str_end)
 {
-	const float scale   = ImGui::GetStyle().FontScaleMain;
 	const ImGuiStyle& s = ImGui::GetStyle();
 	bool is_lf = false;
 
@@ -438,18 +437,18 @@ void imgui_md::render_text(const char* str, const char* str_end)
 			}
 
 			te = ImGui::GetFont()->CalcWordWrapPosition(
-				scale, str, str_end, wl);
+				ImGui::GetFontSize(), str, str_end, wl);
 
 			if (te == str)++te;
 		}
 
-		
+
 		ImGui::TextUnformatted(str, te);
 
 		if (te > str && *(te - 1) == '\n') {
 			is_lf = true;
 		}
-		
+
 		if (!m_href.empty()) {
 
 			ImVec4 c;
@@ -593,7 +592,7 @@ bool imgui_md::check_html(const char* str, const char* str_end)
 void imgui_md::html_div(const std::string& dclass, bool e)
 {
 	//Example:
-#if 0 
+#if 0
 	if (dclass == "red") {
 		if (e) {
 			ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 0, 0, 255));
@@ -799,7 +798,7 @@ ImVec4 imgui_md::get_color() const
 bool imgui_md::get_image(image_info& nfo) const
 {
 	//Use m_href to identify images
-	
+
 	//Example - Imgui font texture
 #ifdef IMGUI_HAS_TEXTURES
 	nfo.texture_id = ImGui::GetIO().Fonts->TexRef.GetTexID();
@@ -817,7 +816,7 @@ void imgui_md::open_url() const
 {
 	//Example:
 
-#if 0	
+#if 0
 	if (!m_is_image) {
 		SDL_OpenURL(m_href.c_str());
 	} else {

--- a/imgui_md.cpp
+++ b/imgui_md.cpp
@@ -54,14 +54,7 @@ imgui_md::imgui_md()
 	m_md.debug_log = nullptr;
 
 	m_md.syntax = nullptr;
-
-	////////////////////////////////////////////////////////////////////////////
-
-	m_table_last_pos = ImVec2(0, 0);
-
 }
-
-
 
 void imgui_md::BLOCK_UL(const MD_BLOCK_UL_DETAIL* d, bool e)
 {
@@ -110,15 +103,16 @@ void imgui_md::BLOCK_LI(const MD_BLOCK_LI_DETAIL*, bool e)
 	}
 }
 
+// Horizontal line - separator
 void imgui_md::BLOCK_HR(bool e)
 {
 	if (!e) {
 		ImGui::NewLine();
 		ImGui::Separator();
-
 	}
 }
 
+// Headings
 void imgui_md::BLOCK_H(const MD_BLOCK_H_DETAIL* d, bool e)
 {
 	if (e) {
@@ -157,127 +151,77 @@ void imgui_md::BLOCK_HTML(bool)
 
 }
 
-void imgui_md::BLOCK_P(bool)
+// Paragraph
+void imgui_md::BLOCK_P(bool /* e */)
 {
-	if (!m_list_stack.empty())return;
+	if (!m_list_stack.empty()) return;
 	ImGui::NewLine();
 }
 
-void imgui_md::BLOCK_TABLE(const MD_BLOCK_TABLE_DETAIL*, bool e)
+void imgui_md::BLOCK_TABLE(const MD_BLOCK_TABLE_DETAIL* d, bool e)
 {
-	if (e) {
-		m_table_row_pos.clear();
-		m_table_col_pos.clear();
-
-		m_table_last_pos = ImGui::GetCursorPos();
-	} else {
-
+	if (e)
+	{
 		ImGui::NewLine();
 
-		if (m_table_border) {
+		ImGui::PushID(table_id);
+		table_id++;
 
-			m_table_last_pos.y = ImGui::GetCursorPos().y;
-
-			m_table_col_pos.push_back(m_table_last_pos.x);
-			m_table_row_pos.push_back(m_table_last_pos.y);
-
-			const ImVec2 wp = ImGui::GetWindowPos();
-			const ImVec2 sp = ImGui::GetStyle().ItemSpacing;
-			const float wx = wp.x + sp.x / 2;
-			const float wy = wp.y - sp.y / 2 - ImGui::GetScrollY();
-
-			for (int i = 0; i < m_table_col_pos.size(); ++i) {
-				m_table_col_pos[i] += wx;
-			}
-
-			for (int i = 0; i < m_table_row_pos.size(); ++i) {
-				m_table_row_pos[i] += wy;
-			}
-
-			////////////////////////////////////////////////////////////////////
-
-			const ImColor c = ImGui::GetStyle().Colors[ImGuiCol_TextDisabled];
-
-			ImDrawList* dl = ImGui::GetWindowDrawList();
-
-			const float xmin = m_table_col_pos.front();
-			const float xmax = m_table_col_pos.back();
-			for (int i = 0; i < m_table_row_pos.size(); ++i) {
-				const float p = m_table_row_pos[i];
-				dl->AddLine(ImVec2(xmin, p), ImVec2(xmax, p), c,
-					i == 1 && m_table_header_highlight ? 2.0f : 1.0f);
-			}
-
-			const float ymin = m_table_row_pos.front();
-			const float ymax = m_table_row_pos.back();
-			for (int i = 0; i < m_table_col_pos.size(); ++i) {
-				const float p = m_table_col_pos[i];
-				dl->AddLine(ImVec2(p, ymin), ImVec2(p, ymax), c, 1.0f);
-			}
+		callEndTable = ImGui::BeginTable(
+			"table", d->col_count, ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg);
+	}
+	else
+	{
+		if (callEndTable)
+		{
+			ImGui::EndTable();
+			ImGui::PopID();
 		}
 	}
-
-
 }
 
+// Enter/exit table header
 void imgui_md::BLOCK_THEAD(bool e)
 {
 	m_is_table_header = e;
-	if (m_table_header_highlight)set_font(e);
+	if (m_table_header_highlight) set_font(e);
+
+	if (!e)
+	{
+		ImGui::TableHeadersRow();
+	}
 }
 
+// Enter/exit table body
 void imgui_md::BLOCK_TBODY(bool e)
 {
 	m_is_table_body = e;
 }
 
+// Enter/exit table row
 void imgui_md::BLOCK_TR(bool e)
 {
-	ImGui::SetCursorPosY(m_table_last_pos.y);
+	if (m_is_table_header) return;
 
-	if (e) {
-		m_table_next_column = 0;
-		ImGui::NewLine();
-		m_table_row_pos.push_back(ImGui::GetCursorPosY());
+	if (e)
+	{
+		ImGui::TableNextRow();
 	}
 }
 
+// Enter/exit table column title
 void imgui_md::BLOCK_TH(const MD_BLOCK_TD_DETAIL* d, bool e)
 {
-	BLOCK_TD(d, e);
 
 }
 
+// Enter/exit table cell
 void imgui_md::BLOCK_TD(const MD_BLOCK_TD_DETAIL*, bool e)
 {
-	if (e) {
-
-		if (m_table_next_column < m_table_col_pos.size()) {
-			ImGui::SetCursorPosX(m_table_col_pos[m_table_next_column]);
-		} else {
-			m_table_col_pos.push_back(m_table_last_pos.x);
-		}
-
-		++m_table_next_column;
-
-		ImGui::Indent(m_table_col_pos[m_table_next_column - 1]);
-		ImGui::SetCursorPos(
-			ImVec2(m_table_col_pos[m_table_next_column - 1], m_table_row_pos.back()));
-
-	} else {
-		const ImVec2 p = ImGui::GetCursorPos();
-		ImGui::Unindent(m_table_col_pos[m_table_next_column - 1]);
-		ImGui::SetCursorPosX(p.x);
-		if (p.y > m_table_last_pos.y)m_table_last_pos.y = p.y;
+	if (e)
+	{
+		ImGui::TableNextColumn();
 	}
-	ImGui::TextUnformatted("");
-
-	if (!m_table_border && e && m_table_next_column==1 ) {
-		ImGui::SameLine(0.0f, 0.0f);
-	} else {
-		ImGui::SameLine();
-	}
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -333,7 +277,6 @@ void imgui_md::SPAN_A(const MD_SPAN_A_DETAIL* d, bool e)
 	set_color(e);
 }
 
-
 void imgui_md::SPAN_EM(bool e)
 {
 	m_is_em = e;
@@ -345,7 +288,6 @@ void imgui_md::SPAN_STRONG(bool e)
 	m_is_strong = e;
 	set_font(e);
 }
-
 
 void imgui_md::SPAN_IMG(const MD_SPAN_IMG_DETAIL* d, bool e)
 {
@@ -391,7 +333,6 @@ void imgui_md::SPAN_CODE(bool)
 
 }
 
-
 void imgui_md::SPAN_LATEXMATH(bool)
 {
 
@@ -422,70 +363,84 @@ void imgui_md::render_text(const char* str, const char* str_end)
 	const ImGuiStyle& s = ImGui::GetStyle();
 	bool is_lf = false;
 
-	while (!m_is_image && str < str_end) {
-
-		const char* te = str_end;
-
-		if (!m_is_table_header) {
-
-			float wl = ImGui::GetContentRegionAvail().x;
-
-			if (m_is_table_body) {
-				wl = (m_table_next_column < m_table_col_pos.size() ?
-					m_table_col_pos[m_table_next_column] : m_table_last_pos.x);
-				wl -= ImGui::GetCursorPosX();
-			}
-
-			te = ImGui::GetFont()->CalcWordWrapPosition(
-				ImGui::GetFontSize(), str, str_end, wl);
-
-			if (te == str)++te;
+	if (!m_is_image && str < str_end)
+	{
+		if (m_is_table_header)
+		{
+			const std::string titolo(str, str_end - str);
+			ImGui::TableSetupColumn(titolo.data());
 		}
+		else
+		{
+			while (str < str_end)
+			{
+				const char *te = str_end;
 
-
-		ImGui::TextUnformatted(str, te);
-
-		if (te > str && *(te - 1) == '\n') {
-			is_lf = true;
-		}
-
-		if (!m_href.empty()) {
-
-			ImVec4 c;
-			if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
-
-				ImGui::SetTooltip("%s", m_href.c_str());
-
-				c = s.Colors[ImGuiCol_ButtonHovered];
-				if (ImGui::IsMouseReleased(0)) {
-					open_url();
+				if (m_is_table_body)
+				{
+					const std::string testo(str, te - str);
+					ImGui::TextWrapped("%s", testo.data());
 				}
-			} else {
-				c = s.Colors[ImGuiCol_Button];
+				else
+				{
+					const float wrap_width = ImGui::GetContentRegionAvail().x;
+
+					te = ImGui::GetFont()->CalcWordWrapPosition(ImGui::GetFontSize(), str, str_end, wrap_width);
+					if (te == str) ++te;
+
+					ImGui::TextUnformatted(str, te);
+				}
+
+				if (te > str && *(te - 1) == '\n')
+				{
+					is_lf = true;
+				}
+
+				if (!m_href.empty())
+				{
+					ImVec4 c;
+					if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal))
+					{
+						ImGui::SetTooltip("%s", m_href.c_str());
+
+						c = s.Colors[ImGuiCol_TextLink];
+						if (ImGui::IsMouseReleased(0))
+						{
+							open_url();
+						}
+					}
+					else
+					{
+						c = s.Colors[ImGuiCol_TextLink];
+					}
+					line(c, true);
+				}
+				else if (m_is_underline)
+				{
+					line(s.Colors[ImGuiCol_Text], true);
+				}
+				if (m_is_strikethrough)
+				{
+					line(s.Colors[ImGuiCol_Text], false);
+				}
+
+				str = te;
+
+				while (str < str_end && *str == ' ')
+					++str;
 			}
-			line(c, true);
-		}
-		if (m_is_underline) {
-			line(s.Colors[ImGuiCol_Text], true);
-		}
-		if (m_is_strikethrough) {
-			line(s.Colors[ImGuiCol_Text], false);
-		}
 
-		str = te;
-
-		while (str < str_end && *str == ' ')++str;
+			if (!is_lf) ImGui::SameLine(0.0f, 0.0f);
+		}
 	}
-
-	if (!is_lf)ImGui::SameLine(0.0f, 0.0f);
 }
-
 
 bool imgui_md::render_entity(const char* str, const char* str_end)
 {
 	const size_t sz = str_end - str;
 	if (strncmp(str, "&nbsp;", sz) == 0) {
-		ImGui::TextUnformatted(""); ImGui::SameLine();
+		ImGui::TextUnformatted("");
+		ImGui::SameLine();
 		return true;
 	}
 	return false;
@@ -549,7 +504,6 @@ static std::string get_div_class(const char* str, const char* str_end)
 	}
 
 	return d.substr(p, pe - p);
-
 }
 
 bool imgui_md::check_html(const char* str, const char* str_end)
@@ -588,11 +542,10 @@ bool imgui_md::check_html(const char* str, const char* str_end)
 	return false;
 }
 
-
 void imgui_md::html_div(const std::string& dclass, bool e)
 {
 	//Example:
-#if 0
+#if 0 
 	if (dclass == "red") {
 		if (e) {
 			ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 0, 0, 255));
@@ -637,11 +590,6 @@ int imgui_md::text(MD_TEXTTYPE type, const char* str, const char* str_end)
 		break;
 	default:
 		break;
-	}
-
-	if (m_is_table_header) {
-		const float x = ImGui::GetCursorPosX();
-		if (x > m_table_last_pos.x)m_table_last_pos.x = x;
 	}
 
 	return 0;
@@ -752,6 +700,7 @@ int imgui_md::span(MD_SPANTYPE type, void* d, bool e)
 int imgui_md::print(const char* str, const char* str_end)
 {
 	if (str >= str_end)return 0;
+	table_id = 0;
 	return md_parse(str, (MD_SIZE)(str_end - str), &m_md, this);
 }
 
@@ -783,7 +732,6 @@ void imgui_md::get_font(font_info &info) const
 		info.font = g_font_bold;
 	}
 #endif
-
 };
 
 ImVec4 imgui_md::get_color() const
@@ -794,12 +742,11 @@ ImVec4 imgui_md::get_color() const
 	return  ImGui::GetStyle().Colors[ImGuiCol_Text];
 }
 
-
 bool imgui_md::get_image(image_info& nfo) const
 {
 	//Use m_href to identify images
-
-	//Example - Imgui font texture
+	
+	//Example - ImGui font texture
 #ifdef IMGUI_HAS_TEXTURES
 	nfo.texture_id = ImGui::GetIO().Fonts->TexRef.GetTexID();
 #else

--- a/imgui_md.cpp
+++ b/imgui_md.cpp
@@ -452,7 +452,7 @@ void imgui_md::render_text(const char* str, const char* str_end)
 		if (!m_href.empty()) {
 
 			ImVec4 c;
-			if (ImGui::IsItemHovered()) {
+			if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
 
 				ImGui::SetTooltip("%s", m_href.c_str());
 

--- a/imgui_md.h
+++ b/imgui_md.h
@@ -84,8 +84,6 @@ protected:
 		ImVec2	size;
 		ImVec2	uv0;
 		ImVec2	uv1;
-		ImVec4	col_tint;
-		ImVec4	col_border;
 	};
 
 	//use m_href to identify image

--- a/imgui_md.h
+++ b/imgui_md.h
@@ -89,7 +89,15 @@ protected:
 	//use m_href to identify image
 	virtual bool get_image(image_info& nfo) const;
 
-	virtual ImFont* get_font() const;
+	struct font_info
+	{
+		// use default font if null
+		ImFont *font;
+		// use default font size if 0.0f (font->LegacySize)
+		float size;
+	};
+
+	virtual void get_font(font_info &info) const;
 	virtual ImVec4 get_color() const;
 
 

--- a/imgui_md.h
+++ b/imgui_md.h
@@ -119,7 +119,7 @@ protected:
 	////////////////////////////////////////////////////////////////////////////
 
 	//current state
-	std::string m_href;//empty if no link/image
+	std::string m_href; // empty if no link/image
 
 	bool m_is_underline=false;
 	bool m_is_strikethrough = false;
@@ -129,7 +129,7 @@ protected:
 	bool m_is_table_body = false;
 	bool m_is_image = false;
 	bool m_is_code = false;
-	unsigned m_hlevel=0;//0 - no heading
+	unsigned m_hlevel = 0; // 0 - no heading
 	
 private:
 
@@ -145,11 +145,9 @@ private:
 
 	static void line(ImColor c, bool under);
 
-	//table state
-	int m_table_next_column = 0;
-	ImVec2 m_table_last_pos;
-	std::vector<float> m_table_col_pos;
-	std::vector<float> m_table_row_pos;
+	// Table state
+	bool callEndTable = false;
+	int table_id      = 0;
 
 	//list state
 	struct list_info


### PR DESCRIPTION
  ## Summary
  - Adds a CMakeLists.txt that exports the `imgui_md` static library target.
  - Fetches ImGui (1.92.6-docking) and md4c (0.5.3) via CPM when they are not
    already provided by the consumer, using `if(NOT TARGET X)` guards. This
    lets imgui_md be consumed cleanly as a CPM dependency in a project that
    already provides its own ImGui (e.g. a renderer that builds ImGui with
    custom backends), without duplicate-target conflicts.
  - Vendors `cmake/get_cpm.cmake` so the project bootstraps standalone.
  - Adds .gitignore for build/, .vscode/, compile_commands.json.

  ## Test plan
  - [x] Builds standalone (clone fresh + `cmake --preset` + `cmake --build`).
  - [x] Consumed via CPM by a project that pre-defines ImGui and md4c targets — fork CMakeLists correctly skips the redundant fetch blocks.